### PR TITLE
Added requirement for elevated prompt in deployment script

### DIFF
--- a/Deploy-AzureOptimizationEngine.ps1
+++ b/Deploy-AzureOptimizationEngine.ps1
@@ -1,3 +1,4 @@
+#Requires -RunAsAdministrator
 param (
     [Parameter(Mandatory = $false)]
     [string] $TemplateUri,


### PR DESCRIPTION
It's just a small addition to the deployment script.
Because it only works with an elevated prompt, i've added the "requires" statement at the beginning.

I've tested it with Windows PowerShell 5.1.18362.752 and PowerShell Core 7.0.3.