### PR TITLE
add CSP subscriptions to supported Quota ID list

### DIFF
--- a/Deploy-AzureOptimizationEngine.ps1
+++ b/Deploy-AzureOptimizationEngine.ps1
@@ -126,7 +126,7 @@ else {
 
 Write-Host "Getting Azure subscriptions (filtering out unsupported ones)..." -ForegroundColor Green
 
-$supportedQuotaIDs = @('EnterpriseAgreement_2014-09-01','PayAsYouGo_2014-09-01','MSDN_2014-09-01','MSDNDevTest_2014-09-01')
+$supportedQuotaIDs = @('EnterpriseAgreement_2014-09-01','PayAsYouGo_2014-09-01','MSDN_2014-09-01','MSDNDevTest_2014-09-01','CSP_2015-05-01')
 
 $subscriptions = Get-AzSubscription | Where-Object { $_.State -eq "Enabled" -and $_.SubscriptionPolicies.QuotaId -in $supportedQuotaIDs }
 


### PR DESCRIPTION
I am aware that CSP subscriptions are not supported by your project. However I could not find any information about why that is the case. Is this simply untested, or are there actual technical restrictions?

Could you maybe elaborate a bit? We are using a CSP subscription and we had successfully deployed AOE in the past, with a few restrictions that for us are minor.

In a recent commit (a9e49349121d13ea77ea024c6c578f43a5d2bad4) you have changed the filtering, which now effectively removes the ability to deploy the AOE into a CSP subscription.

I have added it back to the list and we could deploy it successfully. Which adverse effects do you think this change would have? I believe pricing information is not shown correctly for CSP subscriptions, are there other aspects you know of that will not work correctly?